### PR TITLE
VIKI has buzzer. Also allow PANELOLU2 to be configured without changing library header file.

### DIFF
--- a/LiquidTWI2.cpp
+++ b/LiquidTWI2.cpp
@@ -610,7 +610,7 @@ void LiquidTWI2::setRegister(uint8_t reg, uint8_t value) {
 }
 
 //cycle the buzzer pin at a certain frequency (hz) for a certain duration (ms) 
-void LiquidTWI2::buzz(long duration, uint8_t freq) {
+void LiquidTWI2::buzz(long duration, uint16_t freq) {
   int currentRegister = 0;
   // read gpio register
   Wire.beginTransmission(MCP23017_ADDRESS | _i2cAddr);
@@ -620,7 +620,7 @@ void LiquidTWI2::buzz(long duration, uint8_t freq) {
   Wire.requestFrom(MCP23017_ADDRESS | _i2cAddr, 1);
   currentRegister = wirerecv();
   duration *=1000; //convert from ms to us
-  int period = 1000000 / freq; // period in us
+  long period = 1000000 / freq; // period in us
   long elapsed_time = 0;
   while (elapsed_time < duration)
   {

--- a/LiquidTWI2.h
+++ b/LiquidTWI2.h
@@ -37,7 +37,8 @@
 #define PANELOLU2_ENCODER_B 0x02
 #define PANELOLU2_ENCODER_A 0x01
 
-// readButtons() will only return these bit values
+// readButtons() will only return these bit values 
+// (the Panelolu2 encoder bits are subset of these bits)
 #define ALL_BUTTON_BITS (BUTTON_UP|BUTTON_DOWN|BUTTON_LEFT|BUTTON_RIGHT|BUTTON_SELECT)
 
 #define MCP23008_ADDRESS 0x20
@@ -166,7 +167,7 @@ public:
   //set registers
   void setRegister(uint8_t, uint8_t);
   //make some noise
-  void buzz(long,uint8_t);
+  void buzz(long,uint16_t);
 #endif
 	void setMCPType(uint8_t mcptype) {
 #if defined(MCP23017)&&defined(MCP23008)


### PR DESCRIPTION
Hi Sam,
Here's a couple of changes you might consider. Firstly the production Panucatt VIKI LCD has an onboard buzzer so it is not Panelolu2 only (the early prototypes didn't). 
Also as this is designed to be a library file, it is less than optimal to have to change the library header file to get it to operate in "PANELOLU2" mode. 
So the other change I made is to add an argument to setMCPType to allow you to configure the button bits which are used. I have also maintained the PANELOLU2 define current behavior to avoid any merge problems. 
This does have the minor cost of one each byte and the additional inclusion of readRegister and setRegister for non Panelolu2 panels but I think avoiding the need to have to edit the library headers for the PANELOLU2 is worth it.
Anyway see what you think. 
I have a Marlin pull request open at the moment which adds both Panelolu2 and VIKI support ( https://github.com/ErikZalm/Marlin/pull/407 ). Once an updated LiquidTWI2 library is released then I can enable the buzzer for the VIKI and not require that the library header is changed for the PANELOLU2. 
