### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -31,11 +31,11 @@ scrollDisplayLeft	KEYWORD2
 scrollDisplayRight	KEYWORD2
 createChar	KEYWORD2
 setBacklight	KEYWORD2
-setMCPType      KEYWORD2
-readButtons     KEYWORD2
+setMCPType	KEYWORD2
+readButtons	KEYWORD2
 setRegister	KEYWORD2
-buzz      KEYWORD2
-readRegister     KEYWORD2
+buzz	KEYWORD2
+readRegister	KEYWORD2
 #######################################
 # Constants (LITERAL1)
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords